### PR TITLE
fix glitch on stacked tags animation logic

### DIFF
--- a/app/components/Home/HomePage.tsx
+++ b/app/components/Home/HomePage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -22,14 +21,11 @@ import ProcessHome from "./ProcessHome";
 import HeroContainer from "./HeroContainer";
 import PreFooterLink from "../PreFooterLink";
 import LoadingComponent from "../LoadingComponent";
+import ProjectImages from "./ProjectImages";
 
 import { Project } from "../../Strapi/interfaces/Entities/Project";
 
 import VideoDispatcher from "./VideoDispatcher";
-
-const ProjectImages = dynamic(() => import("./ProjectImages"), {
-    ssr: false,
-});
 
 const transitionSpringPhysics: Spring = {
     type: "spring",

--- a/app/components/tags.tsx
+++ b/app/components/tags.tsx
@@ -10,7 +10,7 @@ import useWindow from "../utils/hooks/useWindow";
 import Image from "next/image";
 import { useNavigation } from "../utils/navigationContext";
 
-gsap.registerPlugin(useGSAP, ScrollTrigger);
+gsap.registerPlugin(ScrollTrigger);
 
 type Props = {
     contentArr: AboutUsTag[];

--- a/app/components/tags.tsx
+++ b/app/components/tags.tsx
@@ -22,7 +22,6 @@ type TagsContentProps = {
     number: string;
     title: string;
     content: string[];
-    setImageLoaded: Dispatch<SetStateAction<boolean>>;
 };
 
 const TagsContent: React.FC<TagsContentProps> = (props) => {
@@ -37,9 +36,6 @@ const TagsContent: React.FC<TagsContentProps> = (props) => {
                 </section>
                 <section className={styles.image_wrapper}>
                     <Image
-                        onLoad={() => {
-                            props.setImageLoaded(true);
-                        }}
                         width={1000}
                         height={1000}
                         className={styles.image}
@@ -61,9 +57,6 @@ const TagsContent: React.FC<TagsContentProps> = (props) => {
             <>
                 <section className={styles.left_content}>
                     <Image
-                        onLoad={() => {
-                            props.setImageLoaded(true);
-                        }}
                         width={1000}
                         height={1000}
                         className={styles.image}
@@ -88,15 +81,12 @@ const TagsContent: React.FC<TagsContentProps> = (props) => {
 };
 
 const Tags: React.FC<Props> = (props: Props) => {
-    const [imgLoad, setImageLoad] = useState(false);
     const tagsRef = useRef<(HTMLDivElement | null)[]>([]);
     const { navigationEvent, setNavigationEvent } = useNavigation();
     const container = useRef<HTMLDivElement | null>(null);
 
     useGSAP(
         () => {
-            if (!imgLoad || !container.current) return;
-
             const tags = tagsRef.current.filter((el) => el !== null);
             const heights = tags.map((el) => el.offsetHeight);
             const space = 20;
@@ -161,7 +151,6 @@ const Tags: React.FC<Props> = (props: Props) => {
                 setNavigationEvent,
                 navigationEvent,
                 container,
-                imgLoad,
             ],
         },
     );
@@ -188,7 +177,6 @@ const Tags: React.FC<Props> = (props: Props) => {
                                 title={_.title}
                                 number={_.number}
                                 content={_.content}
-                                setImageLoaded={setImageLoad}
                             />
                         </div>
                     ))}

--- a/app/components/tags.tsx
+++ b/app/components/tags.tsx
@@ -25,7 +25,7 @@ type TagsContentProps = {
     setImageLoaded: Dispatch<SetStateAction<boolean>>;
 };
 
-const TagsContent = (props: TagsContentProps) => {
+const TagsContent: React.FC<TagsContentProps> = (props) => {
     const windowStatus = useWindow();
 
     if (windowStatus && windowStatus.innerWidth < 768) {
@@ -87,7 +87,7 @@ const TagsContent = (props: TagsContentProps) => {
     }
 };
 
-const Tags = (props: Props) => {
+const Tags: React.FC<Props> = (props: Props) => {
     const [imgLoad, setImageLoad] = useState(false);
     const tagsRef = useRef<(HTMLDivElement | null)[]>([]);
     const { navigationEvent, setNavigationEvent } = useNavigation();

--- a/app/components/tags.tsx
+++ b/app/components/tags.tsx
@@ -8,7 +8,6 @@ import { useGSAP } from "@gsap/react";
 import { AboutUsTag } from "../constants/tags_text";
 import useWindow from "../utils/hooks/useWindow";
 import Image from "next/image";
-import { useIntersectionObserver } from "../utils/hooks/useIntersectionObserver";
 import { useNavigation } from "../utils/navigationContext";
 
 gsap.registerPlugin(useGSAP, ScrollTrigger);
@@ -92,8 +91,7 @@ const Tags = (props: Props) => {
     const [imgLoad, setImageLoad] = useState(false);
     const tagsRef = useRef<(HTMLDivElement | null)[]>([]);
     const { navigationEvent, setNavigationEvent } = useNavigation();
-
-    const { ref: container } = useIntersectionObserver("0px");
+    const container = useRef<HTMLDivElement | null>(null);
 
     useGSAP(
         () => {

--- a/app/components/tags.tsx
+++ b/app/components/tags.tsx
@@ -90,6 +90,7 @@ const TagsContent = (props: TagsContentProps) => {
 
 const Tags = (props: Props) => {
     const [imgLoad, setImageLoad] = useState(false);
+    const tagsRef = useRef<(HTMLDivElement | null)[]>([]);
     const { navigationEvent, setNavigationEvent } = useNavigation();
 
     const { ref: container } = useIntersectionObserver("0px");
@@ -98,7 +99,7 @@ const Tags = (props: Props) => {
         () => {
             if (!imgLoad || !container.current) return;
 
-            const tags = gsap.utils.toArray<HTMLDivElement>(`.${styles.tag}`);
+            const tags = tagsRef.current.filter((el) => el !== null);
             const heights = tags.map((el) => el.offsetHeight);
             const space = 20;
 
@@ -167,6 +168,9 @@ const Tags = (props: Props) => {
         },
     );
 
+    const setTagsRefAt = (ref: HTMLDivElement | null, idx: number): void =>
+        void (tagsRef.current[idx] = ref);
+
     return (
         <motion.div className={`${styles.main}`}>
             <motion.div className={`${styles.tags_wrapper}`}>
@@ -175,7 +179,11 @@ const Tags = (props: Props) => {
                     ref={container}
                 >
                     {props.contentArr.map((_, i) => (
-                        <motion.div key={i} className={`${styles.tag}`}>
+                        <div
+                            key={i}
+                            className={`${styles.tag}`}
+                            ref={(el) => setTagsRefAt(el, i)}
+                        >
                             <TagsContent
                                 i={i}
                                 img={_.img}
@@ -184,7 +192,7 @@ const Tags = (props: Props) => {
                                 content={_.content}
                                 setImageLoaded={setImageLoad}
                             />
-                        </motion.div>
+                        </div>
                     ))}
                 </motion.section>
             </motion.div>


### PR DESCRIPTION
- **refactor(satcked-tags): use element reference instead querying by class name**
- **refactor(stacked-tags): switch intersection observer to standard ref**
- **refactor(stacked-tags): add explicit type definitions to function components**
- **refactor(stacked-tags): remove image ref dependency**
- **refactor(stacked-tags): remove `useGsap()` hook from `registerPlugin()` call**
- **fix(stacked-tags): fix glitch on animation logic**
- **fix(project-images): avoid rendering component dynamically**
